### PR TITLE
Fix link to "first spec" tutorial

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -93,7 +93,7 @@
         <p>Interested in Quickstrom? Check out the following resources to learn more:</p>
         <ul>
           <li><a href="https://docs.quickstrom.io/installation.html">How to install</a></li>
-          <li><a href="https://docs.quickstrom.io/tutorials/first.html">Writing Your First Specification</a></li>
+          <li><a href="https://docs.quickstrom.io/tutorials/free/first.html">Writing Your First Specification</a></li>
           <li><a
               href="https://wickstrom.tech/programming/2020/07/02/the-todomvc-showdown-testing-with-webcheck.html">The
               TodoMVC Showdown</a>, where Quickstrom found problems in multiple implementations</li>


### PR DESCRIPTION
See https://github.com/quickstrom/quickstrom/issues/86